### PR TITLE
Revert "Bump rubyzip from 1.2.1 to 2.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     rouge (2.2.1)
     ruby-enum (0.7.2)
       i18n
-    rubyzip (2.3.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
Reverts DCSCORES/DCSCORESCup.github.io#4